### PR TITLE
Fix day projection

### DIFF
--- a/src/components/ProjectionChart.vue
+++ b/src/components/ProjectionChart.vue
@@ -2,7 +2,7 @@
 import { Line, mixins } from 'vue-chartjs';
 import cloneDeep from 'lodash/cloneDeep';
 import { getLabels, buildChartDataSet, getColor } from '../utils/chartUtils.js';
-import { addToDate } from '../utils/dateManager.js';
+import { addToDate, getDate, getCurrentDate, substractToDate } from '../utils/dateManager.js';
 
 const { reactiveData } = mixins;
 const lineDashSize = 5;
@@ -24,6 +24,7 @@ export default {
     optimistValue: Number,
     pesimistValue: Number,
     numberOfCards: Number,
+    dayOfWeek: String,
   },
   data() {
     return {
@@ -69,16 +70,15 @@ export default {
       return array[array.length - numberTwo];
     },
     fillDatasetGaps(dateLabels, datasetData) {
+      if (dateLabels.length === 0) return;
       let index = 0;
-      const lastLabel = this.getSecondToLastItem(dateLabels);
+      const lastLabel = getDate(substractToDate(getCurrentDate(), 1, this.dateTypeSelector, this.dayOfWeek), this.dateTypeSelector, this.dayOfWeek, true);
       let currentLabel;
       let nextLabel;
       while (currentLabel !== lastLabel) {
         currentLabel = dateLabels[index];
-        nextLabel = addToDate(currentLabel, 1, this.dateTypeSelector);
-        if (!dateLabels.includes(nextLabel)) {
-          this.increaseDataset(dateLabels, datasetData, index, nextLabel);
-        }
+        nextLabel = addToDate(currentLabel, 1, this.dateTypeSelector, this.dayOfWeek);
+        if (!dateLabels.includes(nextLabel)) this.increaseDataset(dateLabels, datasetData, index, nextLabel);
         index++;
       }
     },

--- a/src/components/ProjectionWrapper.vue
+++ b/src/components/ProjectionWrapper.vue
@@ -38,6 +38,7 @@
       v-bind:optimistValue="parseInt(optimistValue)"
       v-bind:pesimistValue="parseInt(pesimistValue)"
       v-bind:numberOfCards="numberOfCards"
+      v-bind:dayOfWeek="dayOfWeek"
     />
   </div>
 </template>

--- a/src/utils/dateManager.js
+++ b/src/utils/dateManager.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-moment().format();
+moment().format('yyyy-MM-dd');
 
 const zeroPadding = 2;
 
@@ -10,9 +10,11 @@ function getDateByDay(date, year, month) {
   return `${year}-${month}-${day}`;
 }
 
-function getDateByWeek(date, year, month, dayOfWeek) {
+function getDateByWeek(date, dayOfWeek) {
   date.day(dayOfWeek);
   const day = date.date().toString().padStart(zeroPadding, '0');
+  const year = date.year();
+  const month = (date.month() + 1).toString().padStart(zeroPadding, '0');
 
   return `${year}-${month}-${day}`;
 }
@@ -36,7 +38,7 @@ function getDate(date, dateTypeSelector, dayOfWeek = 'monday', toMoment = true) 
   case 'day':
     return getDateByDay(momentDate, year, month);
   case 'week':
-    return getDateByWeek(momentDate, year, month, dayOfWeek);
+    return getDateByWeek(momentDate, dayOfWeek);
   case 'month':
     return getDateByMonth(momentDate, year, month);
   default:

--- a/src/utils/dateManager.js
+++ b/src/utils/dateManager.js
@@ -53,7 +53,20 @@ function addToDate(date, value, unit, dayOfWeek = 'monday') {
   return getDate(momentDate, unit, dayOfWeek, false);
 }
 
+function getCurrentDate() {
+  return moment();
+}
+
+function substractToDate(date, value, unit, dayOfWeek = 'monday') {
+  const momentDate = moment(date);
+  momentDate.subtract(value, `${unit}s`);
+
+  return getDate(momentDate, unit, dayOfWeek, false);
+}
+
 export {
   getDate,
   addToDate,
+  getCurrentDate,
+  substractToDate,
 };


### PR DESCRIPTION
# Resumen
Se arreglo un bug donde la proyección por dias no consideraba el dia actual
# Detalles
- Se arreglo un bug en la función getDateByWeek de dateManagetr.js, en la cual cuando había más de un año o un mes dentro de una semana. el cálculo de la fecha no era consistente
- Se modificó la función fillDatasetGaps en ProjectionChart.vue, para que se rellenen correctamente los días y las semanas que no hubo actividad.