### PR TITLE
Fix graphs dates

### DIFF
--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -31,6 +31,7 @@
       v-bind:cardActivities="cardActivities"
       v-bind:listIds="listIds"
       v-bind:boardId="board.id"
+      v-bind:startDate="startDate"
     />
     <LeadTime v-bind:cardActivities="cardActivities" v-bind:endListId="endListId"/>
     <TeamSpeed v-bind:cardActivities="cardActivities" v-bind:endListId="endListId" v-bind:startDate="startDate" v-bind:endDate="endDate"/>

--- a/src/components/CumulativeChart.vue
+++ b/src/components/CumulativeChart.vue
@@ -16,6 +16,7 @@ export default {
     fillBackLists: Boolean,
     dateTypeSelector: String,
     dayOfWeek: String,
+    startDate: Date,
   },
   data() {
     return {
@@ -49,7 +50,7 @@ export default {
         this.activities,
         this.listIds,
         this.fillBackLists,
-        [this.dateTypeSelector, this.dayOfWeek]
+        { dateTypeSelector: this.dateTypeSelector, dayOfWeek: this.dayOfWeek, startDate: this.startDate }
       );
       this.renderChart(this.chartdata, this.chartoptions);
     },

--- a/src/components/CumulativeWrapper.vue
+++ b/src/components/CumulativeWrapper.vue
@@ -30,6 +30,7 @@
       v-bind:fillBackLists="fillBackLists"
       v-bind:dateTypeSelector="dateTypeSelector"
       v-bind:dayOfWeek="dayOfWeek"
+      v-bind:startDate="startDate"
     />
   </div>
 </template>
@@ -47,6 +48,7 @@ export default {
     cardActivities: Array,
     listIds: Array,
     boardId: String,
+    startDate: Date,
   },
   mounted() {
     this.activities = this.cardActivities;

--- a/src/components/ProjectionChart.vue
+++ b/src/components/ProjectionChart.vue
@@ -2,7 +2,7 @@
 import { Line, mixins } from 'vue-chartjs';
 import moment from 'moment';
 import cloneDeep from 'lodash/cloneDeep';
-import { getLabels, buildChartDataSet, getColor } from '../utils/chartUtils.js';
+import { getLabels, buildChartDataSet, getColor, fillDatasetGaps } from '../utils/chartUtils.js';
 import { addToDate, getDate, getCurrentDate, subtractToDate } from '../utils/dateManager.js';
 
 moment().format('yyyy-MM-dd');
@@ -63,37 +63,19 @@ export default {
       this.buildChartData();
       this.renderChart(this.chartdata, this.chartoptions);
     },
-    increaseDataset(dateLabels, datasetData, index, nextLabel) {
-      dateLabels.splice(index + 1, 0, nextLabel);
-      datasetData.splice(index + 1, 0, datasetData[index]);
-    },
     getSecondToLastItem(array) {
       const numberTwo = 2;
 
       return array[array.length - numberTwo];
     },
-    fillDatasetGaps(dateLabels, datasetData) {
-      if (dateLabels.length === 0) return;
-      let index = 0;
-      const lastLabel = getDate(
-        subtractToDate(getCurrentDate(), 1, this.dateTypeSelector, { dayOfWeek: this.dayOfWeek }),
-        this.dateTypeSelector,
-        this.dayOfWeek,
-        true
-      );
-      let currentLabel = dateLabels[index];
-      let nextLabel;
-      while (moment(currentLabel).isSameOrBefore(lastLabel, 'day')) {
-        nextLabel = addToDate(currentLabel, 1, this.dateTypeSelector, this.dayOfWeek);
-        if (!dateLabels.includes(nextLabel)) this.increaseDataset(dateLabels, datasetData, index, nextLabel);
-        index++;
-        currentLabel = dateLabels[index];
-      }
-    },
     buildChartData() {
       let dateLabels = getLabels(this.filteredActivities);
       const currentDataset = buildChartDataSet(this.filteredActivities, dateLabels, 'Current Progression', { color: 'black', fill: false });
-      this.fillDatasetGaps(dateLabels, currentDataset.data);
+      fillDatasetGaps(
+        dateLabels,
+        currentDataset.data,
+        { dateTypeSelector: this.dateTypeSelector, dayOfWeek: this.dayOfWeek }
+      );
       const currentProjection = this.projectData(
         this.speed,
         this.timeUnitsForward,

--- a/src/components/ProjectionChart.vue
+++ b/src/components/ProjectionChart.vue
@@ -2,8 +2,8 @@
 import { Line, mixins } from 'vue-chartjs';
 import moment from 'moment';
 import cloneDeep from 'lodash/cloneDeep';
-import { getLabels, buildChartDataSet, getColor, fillDatasetGaps } from '../utils/chartUtils.js';
-import { addToDate, getDate, getCurrentDate, subtractToDate } from '../utils/dateManager.js';
+import { getLabels, buildChartDataSet, getColor, fillDatasetGaps, fillFromStartDate } from '../utils/chartUtils.js';
+import { addToDate } from '../utils/dateManager.js';
 
 moment().format('yyyy-MM-dd');
 
@@ -28,6 +28,7 @@ export default {
     pesimistValue: Number,
     numberOfCards: Number,
     dayOfWeek: String,
+    startDate: Date,
   },
   data() {
     return {
@@ -74,7 +75,14 @@ export default {
       fillDatasetGaps(
         dateLabels,
         currentDataset.data,
-        { dateTypeSelector: this.dateTypeSelector, dayOfWeek: this.dayOfWeek }
+        { dateTypeSelector: this.dateTypeSelector, dayOfWeek: this.dayOfWeek },
+        false
+      );
+      fillFromStartDate(
+        dateLabels,
+        currentDataset.data,
+        { dateTypeSelector: this.dateTypeSelector, dayOfWeek: this.dayOfWeek, startDate: this.startDate },
+        false
       );
       const currentProjection = this.projectData(
         this.speed,

--- a/src/components/ProjectionWrapper.vue
+++ b/src/components/ProjectionWrapper.vue
@@ -39,6 +39,7 @@
       v-bind:pesimistValue="parseInt(pesimistValue)"
       v-bind:numberOfCards="numberOfCards"
       v-bind:dayOfWeek="dayOfWeek"
+      v-bind:startDate="startDate"
     />
   </div>
 </template>

--- a/src/utils/chartUtils.js
+++ b/src/utils/chartUtils.js
@@ -91,25 +91,41 @@ function increaseLabels(dateLabels, index, nextLabel) {
   dateLabels.splice(index + 1, 0, nextLabel);
 }
 
-function increaseDataset(datasetData, index) {
-  datasetData.splice(index + 1, 0, datasetData[index]);
+function increaseDataset(datasetData, index, isTheStart) {
+  datasetData.splice(index + 1, 0, datasetData[isTheStart ? index : index + 1]);
 }
 
-function fillGap(datasetObject, index, nextLabel, multipleDatasets) {
-  if (multipleDatasets) {
+function fillGap(datasetObject, index, nextLabel, properties) {
+  if (properties.multipleDatasets) {
     if (!datasetObject.dateLabels.includes(nextLabel)) {
       increaseLabels(datasetObject.dateLabels, index, nextLabel);
-      Object.values(datasetObject.datasetData).map((dataset) => increaseDataset(dataset.data, index));
+      Object.values(datasetObject.datasetData).map((dataset) => increaseDataset(dataset.data, index, properties.isTheStart));
     }
   } else {
     if (!datasetObject.dateLabels.includes(nextLabel)) {
       increaseLabels(datasetObject.dateLabels, index, nextLabel);
-      increaseDataset(datasetObject.datasetData, index);
+      increaseDataset(datasetObject.datasetData, index, properties.isTheStart);
     }
   }
 }
 
-function fillDatasetGaps(dateLabels, datasetData, dateParams, multipleDatasets = false) {
+function fillFromStartDate(dateLabels, datasetData, dateParams, multipleDatasets) {
+  if (dateLabels.length === 0) return;
+  let index = -1;
+  let nextLabel = getDate(
+    dateParams.startDate,
+    dateParams.dateTypeSelector,
+    dateParams.dayOfWeek,
+    true
+  );
+  while (!dateLabels.includes(nextLabel)) {
+    fillGap({ dateLabels, datasetData }, index, nextLabel, { multipleDatasets, isTheStart: false });
+    nextLabel = addToDate(nextLabel, 1, dateParams.dateTypeSelector, dateParams.dayOfWeek);
+    index++;
+  }
+}
+
+function fillDatasetGaps(dateLabels, datasetData, dateParams, multipleDatasets) {
   if (dateLabels.length === 0) return;
   let index = 0;
   const lastLabel = getDate(
@@ -122,7 +138,7 @@ function fillDatasetGaps(dateLabels, datasetData, dateParams, multipleDatasets =
   let nextLabel;
   while (moment(currentLabel).isSameOrBefore(lastLabel, 'day')) {
     nextLabel = addToDate(currentLabel, 1, dateParams.dateTypeSelector, dateParams.dayOfWeek);
-    fillGap({ dateLabels, datasetData }, index, nextLabel, multipleDatasets);
+    fillGap({ dateLabels, datasetData }, index, nextLabel, { multipleDatasets, isTheStart: true });
     index++;
     currentLabel = dateLabels[index];
   }
@@ -134,4 +150,5 @@ export {
   buildChartDataSet,
   getColor,
   fillDatasetGaps,
+  fillFromStartDate,
 };

--- a/src/utils/chartUtils.js
+++ b/src/utils/chartUtils.js
@@ -1,3 +1,8 @@
+import moment from 'moment';
+import { addToDate, getDate, getCurrentDate, subtractToDate } from '../utils/dateManager.js';
+
+moment().format('yyyy-MM-dd');
+
 const globalColors = [
   ['rgba(255, 0, 0, 0.1)', 'rgba(255, 0, 0, 0.5)'],
   ['rgba(0, 255, 0, 0.1)', 'rgba(0, 255, 0, 0.5)'],
@@ -82,9 +87,35 @@ function buildChartDataSets(activities, labels, listIds) {
   );
 }
 
+function increaseDataset(dateLabels, datasetData, index, nextLabel) {
+  dateLabels.splice(index + 1, 0, nextLabel);
+  datasetData.splice(index + 1, 0, datasetData[index]);
+}
+
+function fillDatasetGaps(dateLabels, datasetData, dateParams) {
+  if (dateLabels.length === 0) return;
+  let index = 0;
+  const lastLabel = getDate(
+    subtractToDate(getCurrentDate(), 1, dateParams.dateTypeSelector, { dayOfWeek: dateParams.dayOfWeek }),
+    dateParams.dateTypeSelector,
+    dateParams.dayOfWeek,
+    true
+  );
+  let currentLabel = dateLabels[index];
+  let nextLabel;
+  while (moment(currentLabel).isSameOrBefore(lastLabel, 'day')) {
+    nextLabel = addToDate(currentLabel, 1, dateParams.dateTypeSelector, dateParams.dayOfWeek);
+    if (!dateLabels.includes(nextLabel)) increaseDataset(dateLabels, datasetData, index, nextLabel);
+    index++;
+    currentLabel = dateLabels[index];
+  }
+}
+
 export {
   getLabels,
   buildChartDataSets,
   buildChartDataSet,
   getColor,
+  fillDatasetGaps,
+  increaseDataset,
 };

--- a/src/utils/chartUtils.js
+++ b/src/utils/chartUtils.js
@@ -87,12 +87,29 @@ function buildChartDataSets(activities, labels, listIds) {
   );
 }
 
-function increaseDataset(dateLabels, datasetData, index, nextLabel) {
+function increaseLabels(dateLabels, index, nextLabel) {
   dateLabels.splice(index + 1, 0, nextLabel);
+}
+
+function increaseDataset(datasetData, index) {
   datasetData.splice(index + 1, 0, datasetData[index]);
 }
 
-function fillDatasetGaps(dateLabels, datasetData, dateParams) {
+function fillGap(datasetObject, index, nextLabel, multipleDatasets) {
+  if (multipleDatasets) {
+    if (!datasetObject.dateLabels.includes(nextLabel)) {
+      increaseLabels(datasetObject.dateLabels, index, nextLabel);
+      Object.values(datasetObject.datasetData).map((dataset) => increaseDataset(dataset.data, index));
+    }
+  } else {
+    if (!datasetObject.dateLabels.includes(nextLabel)) {
+      increaseLabels(datasetObject.dateLabels, index, nextLabel);
+      increaseDataset(datasetObject.datasetData, index);
+    }
+  }
+}
+
+function fillDatasetGaps(dateLabels, datasetData, dateParams, multipleDatasets = false) {
   if (dateLabels.length === 0) return;
   let index = 0;
   const lastLabel = getDate(
@@ -105,7 +122,7 @@ function fillDatasetGaps(dateLabels, datasetData, dateParams) {
   let nextLabel;
   while (moment(currentLabel).isSameOrBefore(lastLabel, 'day')) {
     nextLabel = addToDate(currentLabel, 1, dateParams.dateTypeSelector, dateParams.dayOfWeek);
-    if (!dateLabels.includes(nextLabel)) increaseDataset(dateLabels, datasetData, index, nextLabel);
+    fillGap({ dateLabels, datasetData }, index, nextLabel, multipleDatasets);
     index++;
     currentLabel = dateLabels[index];
   }
@@ -117,5 +134,4 @@ export {
   buildChartDataSet,
   getColor,
   fillDatasetGaps,
-  increaseDataset,
 };

--- a/src/utils/stackedCardData.js
+++ b/src/utils/stackedCardData.js
@@ -1,5 +1,5 @@
 import { getDate } from './dateManager.js';
-import { getLabels, buildChartDataSets, fillDatasetGaps } from './chartUtils.js';
+import { getLabels, buildChartDataSets, fillDatasetGaps, fillFromStartDate } from './chartUtils.js';
 
 function getActivityData(activity, dateTypeSelector, dayOfWeek) {
   if (activity.type === 'updateCard') {
@@ -40,7 +40,12 @@ function fillRetroactively(activities, listIds) {
 }
 
 export default function (activities, listIds, retroactiveFill, dateParameters) {
-  const activitiesData = activities.map((activity) => getActivityData(activity, ...dateParameters))
+  const activitiesData = activities.map((activity) =>
+    getActivityData(
+      activity,
+      dateParameters.dateTypeSelector,
+      dateParameters.dayOfWeek
+    ))
     .filter((activity) => activity !== null)
     .filter((activity) => listIds.includes(activity.list.id));
   if (retroactiveFill) {
@@ -53,7 +58,17 @@ export default function (activities, listIds, retroactiveFill, dateParameters) {
   fillDatasetGaps(
     dateLabels,
     chartDataset,
-    { dateTypeSelector: dateParameters[0], dayOfWeek: dateParameters[1] },
+    { dateTypeSelector: dateParameters.dateTypeSelector, dayOfWeek: dateParameters.dayOfWeek },
+    true
+  );
+  fillFromStartDate(
+    dateLabels,
+    chartDataset,
+    {
+      dateTypeSelector: dateParameters.dateTypeSelector,
+      dayOfWeek: dateParameters.dayOfWeek,
+      startDate: dateParameters.startDate,
+    },
     true
   );
 

--- a/src/utils/stackedCardData.js
+++ b/src/utils/stackedCardData.js
@@ -1,5 +1,5 @@
 import { getDate } from './dateManager.js';
-import { getLabels, buildChartDataSets } from './chartUtils.js';
+import { getLabels, buildChartDataSets, fillDatasetGaps } from './chartUtils.js';
 
 function getActivityData(activity, dateTypeSelector, dayOfWeek) {
   if (activity.type === 'updateCard') {
@@ -50,6 +50,12 @@ export default function (activities, listIds, retroactiveFill, dateParameters) {
   const dateLabels = getLabels(activitiesData);
 
   const chartDataset = buildChartDataSets(activitiesData, dateLabels, listIds);
+  fillDatasetGaps(
+    dateLabels,
+    chartDataset,
+    { dateTypeSelector: dateParameters[0], dayOfWeek: dateParameters[1] },
+    true
+  );
 
   return {
     labels: dateLabels,


### PR DESCRIPTION
# Resumen
Ahora los gráficos parten de la fecha de inicio, y terminan en la misma fecha.
# Detalles
Se extrajo el método que rellena los espacios en los gráficos a una función externa, para luego ser usado tanto en el gráfico acumulado como el de proyección