### PR TITLE
Choose bug labels

### DIFF
--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -53,6 +53,10 @@
       v-bind:lists="wipLists"
       v-bind:wipLimits="wipLimits"
     />
+    <BugWrapper
+      v-bind:cards="cardsByList[endListId]"
+      v-bind:boardId="board.id"
+    />
   </div>
 </template>
 
@@ -68,6 +72,7 @@ import ProjectionWrapper from './ProjectionWrapper.vue';
 import { get, save } from '../utils/configurationPersistance.js';
 import { subtractToDate } from '../utils/dateManager.js';
 import WIPLists from './WIPLists.vue';
+import BugWrapper from './BugWrapper.vue';
 
 const activitiesRequestLimit = 1000;
 
@@ -81,6 +86,7 @@ export default {
     ProjectionWrapper,
     Datepicker,
     WIPLists,
+    BugWrapper,
   },
   props: {
     board: Object,

--- a/src/components/BugChart.vue
+++ b/src/components/BugChart.vue
@@ -1,0 +1,57 @@
+<script>
+import { Doughnut } from 'vue-chartjs';
+import { getColor } from '../utils/chartUtils.js';
+
+export default {
+  name: 'BugChart',
+  mixins: [Doughnut],
+  props: {
+    cards: Array,
+    bugLabels: Array,
+  },
+  data() {
+    return {
+      chartoptions: {
+        responsive: true,
+        maintainAspectRatio: false,
+      },
+      chartdata: {
+        labels: ['Bug', 'Not a Bug'],
+        datasets: [
+          {
+            data: [],
+            backgroundColor: [
+              getColor('red')[0],
+              getColor('blue')[0],
+            ],
+          },
+        ],
+      },
+    };
+  },
+  watch: {
+    cards() {
+      this.renderData();
+    },
+  },
+  mounted() {
+    this.renderData();
+  },
+  methods: {
+    renderData() {
+      if (this.cards === undefined) this.chartdata.datasets[0].data = [];
+      else {
+        this.chartdata.datasets[0].data = [
+          this.cards.filter((card) =>
+            card.labels.map((element) => element.id).some((label) => this.bugLabels.includes(label))
+          ).length,
+          this.cards.filter((card) =>
+            card.labels.map((element) => element.id).some((label) => !this.bugLabels.includes(label))
+          ).length,
+        ];
+      }
+      this.renderChart(this.chartdata, this.chartoptions);
+    },
+  },
+};
+</script>

--- a/src/components/BugWrapper.vue
+++ b/src/components/BugWrapper.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <h2>Finished Cards</h2>
+    <BugChart
+      v-bind:cards="cards"
+      v-bind:bugLabels="bugLabels"
+    />
+  </div>
+</template>
+
+<script>
+import BugChart from './BugChart.vue';
+import { get } from '../utils/configurationPersistance.js';
+
+export default {
+  name: 'BugWrapper',
+  components: {
+    BugChart,
+  },
+  props: {
+    cards: Array,
+    boardId: String,
+  },
+  data() {
+    return {
+      bugLabels: [],
+    };
+  },
+  mounted() {
+    this.bugLabels = get(`bugLabels_${this.boardId}`, []);
+  },
+};
+</script>


### PR DESCRIPTION
# Resumen
Se creó un gráfico para mostrar la cantidad de tarjetas terminadas que son bugs
# Detalles
- Se agregó la opción de poder elegir que etiquetas corresponden a bugs
- Se creó un gráfico de doughnut para representar los datos