### PR TITLE
Fix duplicate filter

### DIFF
--- a/src/components/LeadTimeChart.vue
+++ b/src/components/LeadTimeChart.vue
@@ -2,7 +2,7 @@
   <div class="stacked-bar-graph">
     <div class="category-container">
       <p class="category-text">
-        {{ $t('leadTime.timeToLive') }} ({{ timeToLive.toLocaleString({maximumFractionDigits: 2}) }}) d
+        {{ $t('leadTime.timeToLive') }} ({{ timeToLive.toLocaleString({maximumFractionDigits: 1}) }}) d
       </p>
       <div class="category-line category-line-top"></div>
     </div>
@@ -24,7 +24,7 @@
     <div class="category-container" :style="leadWidth">
       <div class="category-line category-line-bottom"></div>
       <p class="category-text">
-        {{ $t('leadTime.leadTime') }} ({{ leadTime.toLocaleString({maximumFractionDigits: 2})}}) d
+        {{ $t('leadTime.leadTime') }} ({{ leadTime.toLocaleString({maximumFractionDigits: 1})}}) d
       </p>
     </div>
   </div>
@@ -83,15 +83,18 @@ export default {
   methods: {
     calculate() {
       this.responseTime = getAverageTime(
-        ...getCardsBetweenTwoLists(this.cardActivities, this.backlogListIds, this.progressListIds)
+        ...getCardsBetweenTwoLists(this.cardActivities, this.backlogListIds, this.progressListIds),
+        1
       );
       if (this.responseTime === 'NaN') this.responseTime = '0';
       this.cycleTime = getAverageTime(
-        ...getCardsBetweenTwoLists(this.cardActivities, this.progressListIds, this.endListIds)
+        ...getCardsBetweenTwoLists(this.cardActivities, this.progressListIds, this.endListIds),
+        1
       );
       if (this.cycleTime === 'NaN') this.cycleTime = '0';
       this.deployTime = getAverageTime(
-        ...getCardsBetweenTwoLists(this.cardActivities, this.endListIds, this.productionListIds)
+        ...getCardsBetweenTwoLists(this.cardActivities, this.endListIds, this.productionListIds),
+        1
       );
       if (this.deployTime === 'NaN') this.deployTime = '0';
     },

--- a/src/utils/speedUtil.js
+++ b/src/utils/speedUtil.js
@@ -7,25 +7,21 @@ function sortDate(activity1, activity2) {
   return moment(activity1.date).diff(activity2.date, 'days');
 }
 
-function filterActivitiesByMovedTwiceInSameList(activity, _, array) {
-  return array.filter((filterActivity) => filterActivity.id === activity.id)
-    .sort((activity1, activity2) => (activity1.date - activity2.date))[0]
-    .id === activity.id;
-}
-
-function filterDuplicates(activity, _, array) {
-  if (array.filter((filterActivity) => filterActivity.id === activity.id).length === 1) {
-    return true;
-  }
-
-  return filterActivitiesByMovedTwiceInSameList(activity, _, array);
+function filterDuplicates(activities) {
+  return activities
+    .filter((activity) =>
+      activities.filter((filteredActivity) => filteredActivity.id === activity.id).length === 1
+    ).concat(Object.values(
+      activities.filter((activity) =>
+        activities.filter((filteredActivity) => filteredActivity.id === activity.id).length > 1
+      ).reduce((acc, cur) => Object.assign(acc, { [cur.id]: cur }), {}))
+    );
 }
 
 function filterActivities(activities, endListIds, dateTypeSelector, dayOfWeek = 'monday') {
-  return activities.filter((activity) => activity.type === 'updateCard')
+  return filterDuplicates(activities.filter((activity) => activity.type === 'updateCard')
     .filter((activity) => endListIds.includes(activity.data.listAfter.id))
-    .map((activity) => ({ id: activity.data.card.id, date: getDate(activity.date, dateTypeSelector, dayOfWeek) }))
-    .filter((activity, _, array) => filterDuplicates(activity, _, array))
+    .map((activity) => ({ id: activity.data.card.id, date: getDate(activity.date, dateTypeSelector, dayOfWeek) })))
     .sort(sortDate);
 }
 


### PR DESCRIPTION
# Resumen
Se arregló un bug donde las tarjetas duplicadas no se estaban filtrando bien, que afectaba al grafico de proyección y al calculo del lead time. además se redujeron los decimales del leadtime a 1 decimal en vez de 2