### PR TITLE
fix(projection chart): fix speed calculation for projection

### DIFF
--- a/src/components/ProjectionWrapper.vue
+++ b/src/components/ProjectionWrapper.vue
@@ -141,7 +141,12 @@ export default {
   },
   methods: {
     localSpeedProjection(filteredActivities) {
-      return speedProjection(filteredActivities, this.startDate, this.endDate);
+      return speedProjection(
+        filteredActivities.filter((activity) =>
+          moment(activity.date).isSameOrAfter(this.startDate, `${this.dateTypeSelector}s`)),
+        this.startDate,
+        this.endDate
+      );
     },
     generateData() {
       this.filteredActivities = excludeActivities(


### PR DESCRIPTION
# Resumen
Se arregló la forma en la que se calcula la velocidad del equipo para la proyección, la que antes generaba numeros demaciado altos